### PR TITLE
feat: add network feature flag for optional reqwest/tokio dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0.99"
 clap = { version = "4.5.46", features = ["derive"], optional = true }
-reqwest = { version = "0.12.23", features = ["gzip", "json"] }
+reqwest = { version = "0.12.23", features = ["gzip", "json"], optional = true }
 serde = { version = "1.0.219", features = ["derive", "alloc"] }
 serde_json = { version = "1.0.143", features = ["alloc"] }
 tokio = { version = "1.47.1", features = [
@@ -29,7 +29,9 @@ tokio = { version = "1.47.1", features = [
 ] }
 
 [features]
-cli = ["dep:clap", "dep:tokio"]
+default = []
+cli = ["dep:clap", "dep:tokio", "network"]
+network = ["dep:reqwest", "dep:tokio"]
 
 [[bin]]
 name = "anime-game-data"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,14 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 
+#[cfg(feature = "network")]
 mod dimbreath;
 mod game_data;
 mod types;
 
+#[cfg(feature = "network")]
 use dimbreath::Dimbreath;
+#[cfg(feature = "network")]
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 pub use types::*;
@@ -19,6 +22,7 @@ use crate::game_data::{
     ReliquaryMainPropExcelConfigDataEntry, WeaponExcelConfigDataEntry,
 };
 
+#[cfg(feature = "network")]
 trait GameDataSource {
     async fn get_latest_hash(&self) -> Result<String>;
     async fn get_json_file<T: DeserializeOwned>(&self, git_ref: &str, path: &str) -> Result<T>;
@@ -184,10 +188,12 @@ impl AnimeGameData {
         self.db.is_some()
     }
 
+    #[cfg(feature = "network")]
     pub async fn needs_update(&self) -> Result<bool> {
         self.needs_update_impl(&Dimbreath::new()?).await
     }
 
+    #[cfg(feature = "network")]
     async fn needs_update_impl<Source: GameDataSource>(&self, source: &Source) -> Result<bool> {
         let Some(db) = &self.db else {
             return Ok(true);
@@ -195,10 +201,12 @@ impl AnimeGameData {
         Ok(db.git_hash != source.get_latest_hash().await?)
     }
 
+    #[cfg(feature = "network")]
     pub async fn update(&mut self) -> Result<()> {
         self.update_impl(&Dimbreath::new()?).await
     }
 
+    #[cfg(feature = "network")]
     async fn update_impl<Source: GameDataSource>(&mut self, source: &Source) -> Result<()> {
         tracing::info!("Checking for updated data");
         // Check if data is already up to date
@@ -258,6 +266,7 @@ impl AnimeGameData {
         Ok(())
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_affix_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -280,6 +289,7 @@ impl AnimeGameData {
             .collect())
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_artifact_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -308,6 +318,7 @@ impl AnimeGameData {
         Ok(map)
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_character_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -328,6 +339,7 @@ impl AnimeGameData {
             .collect())
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_material_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -348,6 +360,7 @@ impl AnimeGameData {
             .collect())
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_property_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -365,6 +378,7 @@ impl AnimeGameData {
             .collect())
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_set_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -386,6 +400,7 @@ impl AnimeGameData {
             .collect())
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_skill_type_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -407,6 +422,7 @@ impl AnimeGameData {
         Ok(type_map)
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_text_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,
@@ -416,6 +432,7 @@ impl AnimeGameData {
             .await
     }
 
+    #[cfg(feature = "network")]
     async fn fetch_weapon_map<Source: GameDataSource>(
         source: &Source,
         git_ref: &str,


### PR DESCRIPTION
Add a `network` feature flag that gates all network-dependent functionality (remote data fetching, update checks) behind `cfg(feature = "network")`.

This allows downstream projects targeting platforms without network requirements (e.g., Android) to use the library without pulling in `reqwest` and `tokio` dependencies.

**Changes:**
- Make `reqwest` and `tokio` optional dependencies gated by `network` feature
- Add `#[cfg(feature = "network")]` to all methods that require network access (`update`, `needs_update`, `fetch_*_map`, etc.)
- Gate `dimbreath` module and `GameDataSource` trait behind `network` feature
- Add `default = []` to avoid enabling `network` by default
- Update `cli` feature to include `network`